### PR TITLE
add the c99 isblank() function

### DIFF
--- a/ctype.asm
+++ b/ctype.asm
@@ -103,6 +103,32 @@ yes	lda	#1
 
 ****************************************************************
 *
+*  int isblank (int c)
+*
+*  Inputs:
+*	4,S - digit to test
+*
+*  Outputs:
+*	A - result
+*
+****************************************************************
+*
+isblank	start
+
+	lda	4,S	fetch the operand
+	tax
+	lda	2,S	remove parm from stack
+	sta	4,S
+	pla
+	sta	1,S
+	inx		form the result
+	lda	>__ctype2,X
+	and	#_blank
+	rtl
+	end
+
+****************************************************************
+*
 *  int iscntrl (int c)
 *
 *  Inputs:
@@ -844,7 +870,7 @@ __ctype2 start
 	dc	i1'0'					$06
 	dc	i1'0'					$07
 	dc	i1'0'					$08
-	dc	i1'0'					$09
+	dc	i1'_blank'				$09
 	dc	i1'0'					$0A
 	dc	i1'0'					$0B
 	dc	i1'0'					$0C
@@ -867,7 +893,7 @@ __ctype2 start
 	dc	i1'0'					$1D
 	dc	i1'0'					$1E
 	dc	i1'0'					$1F
-	dc	i1'0'					' '
+	dc	i1'_blank'				' '
 	dc	i1'0'					!
 	dc	i1'0'					"
 	dc	i1'0'					#

--- a/equates.asm
+++ b/equates.asm
@@ -36,6 +36,7 @@ _print   gequ  $80                      [' '..'~']
 _csym    gequ  $01                      ['0'..'9','A'..'Z','a'..'z','_']
 _csymf   gequ  $02                      ['A'..'Z','a'..'z'.'_']
 _octal   gequ  $04                      ['0'..'7']
+_blank   gequ  $08                      ['\t', ' ']
 ;
 ;  signal numbers
 ;


### PR DESCRIPTION
GNO's ORCALib includes the isblank() (space or tab) function, which was added to the C99 standard. `ctype.h` header needs to be updated as well -

```
#define __blank         0x08
int             isblank(int);
#define isblank(c)      ((__ctype2)[(c)+1] & __blank)
``` 

